### PR TITLE
Partial group route bug

### DIFF
--- a/routes/group/[slug].tsx
+++ b/routes/group/[slug].tsx
@@ -45,7 +45,7 @@ export default function CoursePage(props: PageProps<Props>) {
               </h2>
               <IconChevronDown />
             </div>
-            <div class="flex flex-col mt-2 pr-3 gap-3">
+            <div f-client-nav={false} class="flex flex-col mt-2 pr-3 gap-3">
               {foundCourseGroup.courses.map((course) => (
                 <a
                   title={course.title}


### PR DESCRIPTION
Fixes #55
In this pull request, I have set `f-client-nav` to false in the group route. This change is made to disable client-side navigation for group route.
Generally, navigation from any page to lesson page with f-client-nav make problems so we disable it in the components that contain links to lessons.
Thanks